### PR TITLE
render_to_response is depricated with django 1.8 and removed with 1.10

### DIFF
--- a/rolodex/views.py
+++ b/rolodex/views.py
@@ -137,7 +137,7 @@ def search_org(request, org_slug):
 	node.tags = node.tags.all()
 	tags = Tag.objects.all()
 	if isDjango18:
-		return render(request, 'rolodex/org.html', {'node': node, 'tags': tags, }, context_instance=RequestContext(request))
+		return render(request, 'rolodex/org.html', {'node': node, 'tags': tags, })
 	else:
 		return render_to_response('rolodex/org.html', {'node': node, 'tags': tags, }, context_instance=RequestContext(request))
 

--- a/rolodex/views.py
+++ b/rolodex/views.py
@@ -1,5 +1,15 @@
 from django.contrib.auth.decorators import login_required, permission_required
-from django.shortcuts import redirect, render_to_response
+
+# render_to_response is depricated with django 1.8 and removed with 1.10
+from distutils.version import StrictVersion
+
+from django import get_version
+isDjango18 = StrictVersion(get_version()) >= StrictVersion('1.8')
+if isDjango18:
+	from django.shortcuts import redirect, render
+else:
+	from django.shortcuts import redirect, render_to_response
+	
 from django.template import RequestContext
 from django.http import HttpResponse, JsonResponse
 from django.db.models import Q
@@ -42,7 +52,10 @@ def secure(view):
 
 @secure
 def home(request):
-	return render_to_response('rolodex/home.html', {}, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(request, 'rolodex/home.html', {})
+	else:
+		return render_to_response('rolodex/home.html', {}, context_instance=RequestContext(request))
 
 
 ############################################################################
@@ -66,7 +79,11 @@ def new_org(request):
 			else:
 				org.delete()
 				form = OrgForm(request.POST)
-	return render_to_response('rolodex/new_org.html', {'form': form, 'formset': formset, }, context_instance=RequestContext(request))
+
+	if isDjango18:
+		return render(request, 'rolodex/new_org.html', {'form': form, 'formset': formset, })
+	else:
+		return render_to_response('rolodex/new_org.html', {'form': form, 'formset': formset, }, context_instance=RequestContext(request))
 
 
 @secure
@@ -86,7 +103,10 @@ def edit_org(request, org_slug):
 				org_node.save()
 				return redirect('rolodex_org', org.slug)
 
-	return render_to_response('rolodex/new_org.html', {'form': form, 'formset': formset, 'orgNode': org_node, 'edit': True}, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(request, 'rolodex/new_org.html', {'form': form, 'formset': formset, 'orgNode': org_node, 'edit': True})
+	else:
+		return render_to_response('rolodex/new_org.html', {'form': form, 'formset': formset, 'orgNode': org_node, 'edit': True}, context_instance=RequestContext(request))
 
 
 @permission_required('rolodex.delete_org')
@@ -95,7 +115,10 @@ def delete_org(request, org_slug):
 	if request.method == "POST":
 		org.delete()
 		return redirect('rolodex_home')
-	return render_to_response('rolodex/delete.html', {'org': org}, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(request, 'rolodex/delete.html', {'org': org})
+	else:
+		return render_to_response('rolodex/delete.html', {'org': org}, context_instance=RequestContext(request))
 
 
 @secure
@@ -113,14 +136,20 @@ def search_org(request, org_slug):
 	node.documents = Document.objects.filter(org=node)
 	node.tags = node.tags.all()
 	tags = Tag.objects.all()
-	return render_to_response('rolodex/org.html', {'node': node, 'tags': tags, }, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(request, 'rolodex/org.html', {'node': node, 'tags': tags, }, context_instance=RequestContext(request))
+	else:
+		return render_to_response('rolodex/org.html', {'node': node, 'tags': tags, }, context_instance=RequestContext(request))
 
 
 @secure
 def org_map(request, org_slug):
 	node = Org.objects.get(slug=org_slug)
 	hops = int(request.GET.get('hops', 3))
-	return render_to_response('rolodex/orgMap.html', {'node': node, 'hops': hops}, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(request, 'rolodex/orgMap.html', {'node': node, 'hops': hops})
+	else:
+		return render_to_response('rolodex/orgMap.html', {'node': node, 'hops': hops}, context_instance=RequestContext(request))
 
 
 @secure
@@ -164,7 +193,10 @@ def new_org_relation(request, org_slug):
 				from_ent.add_org2org(to_ent, **{'relation': relation, 'hierarchy': hierarchy})
 				saved = True
 	org_node = Org.objects.get(slug=org_slug)
-	return render_to_response('rolodex/new_relation.html', {'orgNode': org_node, 'pForm': org2p_form, 'orgForm': org2org_form, 'saved': saved}, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(request, 'rolodex/new_relation.html', {'orgNode': org_node, 'pForm': org2p_form, 'orgForm': org2org_form, 'saved': saved})
+	else:
+		return render_to_response('rolodex/new_relation.html', {'orgNode': org_node, 'pForm': org2p_form, 'orgForm': org2org_form, 'saved': saved}, context_instance=RequestContext(request))
 
 
 @secure
@@ -179,7 +211,10 @@ def new_org_doc(request, org_slug=None):
 	else:
 		node = Org.objects.get(slug=org_slug)
 		doc_form = DocumentForm(initial={'org': node})
-	return render_to_response('rolodex/new_doc.html', {'node': node, 'entity': 'org', 'docForm': doc_form}, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(requet, 'rolodex/new_doc.html', {'node': node, 'entity': 'org', 'docForm': doc_form})
+	else:
+		return render_to_response('rolodex/new_doc.html', {'node': node, 'entity': 'org', 'docForm': doc_form}, context_instance=RequestContext(request))
 
 
 ############################################################################
@@ -213,7 +248,10 @@ def new_person(request, org_slug=None):
 				form = PersonForm(request.POST)
 
 	primary = Org.objects.get(slug=org_slug)
-	return render_to_response('rolodex/new_person.html', {'form': form, 'formset': formset, 'orgNode': org_slug, 'primary': primary, 'success': success}, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(request, 'rolodex/new_person.html', {'form': form, 'formset': formset, 'orgNode': org_slug, 'primary': primary, 'success': success})
+	else:
+		return render_to_response('rolodex/new_person.html', {'form': form, 'formset': formset, 'orgNode': org_slug, 'primary': primary, 'success': success}, context_instance=RequestContext(request))
 
 
 @secure
@@ -238,7 +276,10 @@ def new_person_no_org(request, org_slug=None):
 			else:
 				person.delete()
 				form = PersonForm(request.POST)
-	return render_to_response('rolodex/new_person.html', {'form': form, 'formset': formset, 'orgNode': org_slug, 'primary': None, 'success': success}, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(request, 'rolodex/new_person.html', {'form': form, 'formset': formset, 'orgNode': org_slug, 'primary': None, 'success': success})
+	else:
+		return render_to_response('rolodex/new_person.html', {'form': form, 'formset': formset, 'orgNode': org_slug, 'primary': None, 'success': success}, context_instance=RequestContext(request))
 
 
 @secure
@@ -264,7 +305,10 @@ def edit_person(request, person_slug):
 		primary = employer[0].to_ent
 	else:
 		primary = "N/A"
-	return render_to_response('rolodex/new_person.html', {'form': form, 'formset': formset, 'personNode': peep, 'primary': primary, 'edit': True}, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(request, 'rolodex/new_person.html', {'form': form, 'formset': formset, 'personNode': peep, 'primary': primary, 'edit': True})
+	else:
+		return render_to_response('rolodex/new_person.html', {'form': form, 'formset': formset, 'personNode': peep, 'primary': primary, 'edit': True}, context_instance=RequestContext(request))
 
 
 @permission_required('rolodex.delete_person')
@@ -273,7 +317,10 @@ def delete_person(request, person_slug):
 	if request.method == "POST":
 		peep.delete()
 		return redirect('rolodex_home')
-	return render_to_response('rolodex/delete.html', {'peep': peep}, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(request, 'rolodex/delete.html', {'peep': peep})
+	else:
+		return render_to_response('rolodex/delete.html', {'peep': peep}, context_instance=RequestContext(request))
 
 
 @secure
@@ -295,14 +342,20 @@ def search_person(request, person_slug):
 	node.documents = Document.objects.filter(person=node)
 	node.tags = node.tags.all()
 	tags = Tag.objects.all()
-	return render_to_response('rolodex/person.html', {'node': node, 'tags': tags, }, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(request, 'rolodex/person.html', {'node': node, 'tags': tags, })
+	else:
+		return render_to_response('rolodex/person.html', {'node': node, 'tags': tags, }, context_instance=RequestContext(request))
 
 
 @secure
 def person_map(request, person_slug):
 	node = Person.objects.get(slug=person_slug)
 	hops = int(request.GET.get('hops', 3))
-	return render_to_response('rolodex/personMap.html', {'node': node, 'hops': hops}, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(request, 'rolodex/personMap.html', {'node': node, 'hops': hops})
+	else:
+		return render_to_response('rolodex/personMap.html', {'node': node, 'hops': hops}, context_instance=RequestContext(request))
 
 
 @secure
@@ -350,7 +403,10 @@ def new_person_relation(request, person_slug):
 				from_ent.add_p2org(to_ent, **{'relation': relation})
 				saved = True
 	peep_node = Person.objects.get(slug=person_slug)
-	return render_to_response('rolodex/new_relation.html', {'peepNode': peep_node, 'pForm': p2p_form, 'orgForm': p2org_form, 'saved': saved}, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(request, 'rolodex/new_relation.html', {'peepNode': peep_node, 'pForm': p2p_form, 'orgForm': p2org_form, 'saved': saved})
+	else:
+		return render_to_response('rolodex/new_relation.html', {'peepNode': peep_node, 'pForm': p2p_form, 'orgForm': p2org_form, 'saved': saved}, context_instance=RequestContext(request))
 
 
 @secure
@@ -366,7 +422,10 @@ def new_person_doc(request, person_slug=None):
 	else:
 		node = Person.objects.get(slug=person_slug)
 		doc_form = DocumentForm(initial={'person': node})
-	return render_to_response('rolodex/new_doc.html', {'node': node, 'entity': 'person', 'docForm': doc_form}, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(request, 'rolodex/new_doc.html', {'node': node, 'entity': 'person', 'docForm': doc_form})
+	else:
+		return render_to_response('rolodex/new_doc.html', {'node': node, 'entity': 'person', 'docForm': doc_form}, context_instance=RequestContext(request))
 
 
 @secure
@@ -435,7 +494,10 @@ def search_tag(request, tag_name=None):
 	tag['peeps'] = Person.objects.filter(tags__name=tag_name)
 	tag['orgs'] = Org.objects.filter(tags__name=tag_name)
 	tag['all_tags'] = Tag.objects.all()
-	return render_to_response('rolodex/tag_search.html', {'tag': tag, }, context_instance=RequestContext(request))
+	if isDjango18:
+		return render(requet, 'rolodex/tag_search.html', {'tag': tag, })
+	else:
+		return render_to_response('rolodex/tag_search.html', {'tag': tag, }, context_instance=RequestContext(request))
 
 #################################################################
 # SELECT SEARCH FUNCTIONS #


### PR DESCRIPTION
Added a conditional execution which uses the old render_to_response for
versions lower than 1.8 of django and uses the preferred render with
1.8 forward.